### PR TITLE
Create subscription endpoint

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -2,8 +2,15 @@ class Api::V1::SubscriptionsController < ApplicationController
   def create
     details = JSON.parse(request.body.read, symbolize_names: true)
     tea = Tea.find_by(id: details[:tea_id])
+    customer = Customer.find_by(id: details[:customer_id])
+
+    if !tea || !customer
+      render json: {errors: "Tea or customer could not be found"}, status: 404
+      return
+    end
+
     sub = Subscription.new(
-      customer_id: details[:customer_id],
+      customer_id: customer.id,
       tea_id: tea.id,
       title: tea.title,
       price: details[:price],

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::SubscriptionsController < ApplicationController
+  def create
+    details = JSON.parse(request.body.read, symbolize_names: true)
+    tea = Tea.find_by(id: details[:tea_id])
+    sub = Subscription.new(
+      customer_id: details[:customer_id],
+      tea_id: tea.id,
+      title: tea.title,
+      price: details[:price],
+      frequency: details[:frequency]
+    )
+
+    if sub.save
+      render json: {success: "Subscription created successfully"}, status: 201
+    else
+      render json: {errors: sub.errors.full_messages.to_sentence}, status: 400
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+
+  namespace :api do 
+    namespace :v1 do
+      resources :subscriptions, only: [:create]
+    end
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+Customer.create(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ave")
+Customer.create(first_name: "Chicken", last_name: "Bird", email: "chicken@gmail.com", address: "01 Bird Cir")
+Tea.create(title: "First Good Tea", description: "It's just a cool tea", temperature: 100, brew_time: 2)
+Tea.create(title: "Second Good Tea", description: "It's just another sweet tea", temperature: 90, brew_time: 3)
+Tea.create(title: "Third Good Tea", description: "It's just a third great tea", temperature: 101, brew_time: 5)

--- a/spec/requests/subscriptions/create_subscription.rb
+++ b/spec/requests/subscriptions/create_subscription.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "Create Subscription", type: :request do
+  describe "When I post to the /api/v1/subscriptions endpoint" do
+    it "A subscription is created and I get a successful response" do
+      tea = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
+      customer = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
+      params = {
+        customer_id: customer.id,
+        tea_id: tea.id,
+        price: 30.20,
+        frequency: 30
+      }
+
+      post "/api/v1/subscriptions", params: params, as: :json
+      expect(response).to be_successful
+      
+      subscription = Subscription.last
+      expect(subscription.customer_id).to eq(customer.id)
+      expect(subscription.tea_id).to eq(tea.id)
+      expect(subscription.price).to eq(params[:price])
+      expect(subscription.frequency).to eq(params[:frequency])
+      expect(subscription.title).to eq(tea.title)
+      expect(subscription.status).to eq(1)
+    end
+  end
+end

--- a/spec/requests/subscriptions/create_subscription.rb
+++ b/spec/requests/subscriptions/create_subscription.rb
@@ -24,4 +24,60 @@ RSpec.describe "Create Subscription", type: :request do
       expect(subscription.status).to eq("active")
     end
   end
+
+  describe "sad paths" do
+    it "Returns a meaningful error if content is missing" do
+      tea = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
+      customer = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
+      params = {
+        customer_id: customer.id,
+        tea_id: tea.id,
+        frequency: 30
+      }
+
+      post "/api/v1/subscriptions", params: params, as: :json
+      expect(response).to_not be_successful
+      errors = JSON.parse(response.body, symbolize_names: true)
+
+      expect(errors).to be_a Hash
+      expect(errors).to have_key(:errors)
+      expect(errors[:errors]).to eq("Price can't be blank")
+    end
+
+    it "returns a meaningful error if tea does not exist" do
+      customer = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
+      params = {
+        customer_id: customer.id,
+        tea_id: 1,
+        price: 30.10,
+        frequency: 30
+      }
+
+      post "/api/v1/subscriptions", params: params, as: :json
+      expect(response).to_not be_successful
+      errors = JSON.parse(response.body, symbolize_names: true)
+
+      expect(errors).to be_a Hash
+      expect(errors).to have_key(:errors)
+      expect(errors[:errors]).to eq("Tea or customer could not be found")
+    end
+
+    it "returns a meaningful error if customer does not exist" do
+      tea = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
+      params = {
+        customer_id: 1,
+        tea_id: tea.id,
+        price: 30.10,
+        frequency: 30
+      }
+
+      post "/api/v1/subscriptions", params: params, as: :json
+      expect(response).to_not be_successful
+      errors = JSON.parse(response.body, symbolize_names: true)
+
+      expect(errors).to be_a Hash
+      expect(errors).to have_key(:errors)
+      expect(errors[:errors]).to eq("Tea or customer could not be found")
+    end
+  end
 end

--- a/spec/requests/subscriptions/create_subscription.rb
+++ b/spec/requests/subscriptions/create_subscription.rb
@@ -21,7 +21,7 @@ RSpec.describe "Create Subscription", type: :request do
       expect(subscription.price).to eq(params[:price])
       expect(subscription.frequency).to eq(params[:frequency])
       expect(subscription.title).to eq(tea.title)
-      expect(subscription.status).to eq(1)
+      expect(subscription.status).to eq("active")
     end
   end
 end


### PR DESCRIPTION
Resolves: #6 
Routes: POST /api/v1/subscriptions
Controllers: subscriptions#create
Testing: Full request testing for happy and sad path of subscription creation

Features: Allows for a subscription to be created via a POST to the subscriptions endpoint. Expects a request body of: customer_id, tea_id, price, frequency