### PR TITLE
Subscription cancellation endpoint

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -27,7 +27,11 @@ class Api::V1::SubscriptionsController < ApplicationController
   def destroy
     subscription = Subscription.find_by(id: params[:id])
 
-    subscription.update(status: 0)
-    render json: {success: "Subscription has been successfully cancelled"}, status: 200
+    if subscription
+      subscription.update(status: 0)
+      render json: {success: "Subscription has been successfully cancelled"}, status: 200
+    else
+      render json: {errors: "Subscription could not be found"}, status: 404
+    end
   end
 end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -24,8 +24,8 @@ class Api::V1::SubscriptionsController < ApplicationController
     end
   end
 
-  def destroy
-    subscription = Subscription.find_by(id: params[:id])
+  def update
+    subscription = Subscription.find_by(id: params[:subscription_id])
 
     if subscription
       subscription.update(status: 0)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -23,4 +23,11 @@ class Api::V1::SubscriptionsController < ApplicationController
       render json: {errors: sub.errors.full_messages.to_sentence}, status: 400
     end
   end
+
+  def destroy
+    subscription = Subscription.find_by(id: params[:id])
+
+    subscription.update(status: 0)
+    render json: {success: "Subscription has been successfully cancelled"}, status: 200
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,9 @@ Rails.application.routes.draw do
 
   namespace :api do 
     namespace :v1 do
-      resources :subscriptions, only: [:create, :destroy]
+      resources :subscriptions, only: [:create] do
+        patch "/cancel", to: "subscriptions#update"
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   namespace :api do 
     namespace :v1 do
-      resources :subscriptions, only: [:create]
+      resources :subscriptions, only: [:create, :destroy]
     end
   end
 end

--- a/spec/requests/subscriptions/cancel_subscription.rb
+++ b/spec/requests/subscriptions/cancel_subscription.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe "Delete/Cancel Subscription", type: :request do
+RSpec.describe "Cancel Subscription", type: :request do
   before(:each) do
     @tea = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
     @customer = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
   end
 
-  describe "When a user sends a DELETE request to /api/v1/subscriptions/{id}" do
+  describe "When a user sends a patch request to /api/v1/subscriptions/{id}/cancel" do
     it "the requested subscription is cancelled" do
       subscription = Subscription.create!(tea_id: @tea.id, customer_id: @customer.id, title: @tea.title, price: 100.10, frequency: 7)
       expect(subscription).to be_a Subscription
@@ -17,7 +17,7 @@ RSpec.describe "Delete/Cancel Subscription", type: :request do
       expect(subscription.price).to eq(100.10)
       expect(subscription.frequency).to eq(7)
 
-      delete "/api/v1/subscriptions/#{subscription.id}"
+      patch "/api/v1/subscriptions/#{subscription.id}/cancel"
       expect(response).to be_successful
 
       subscription = Subscription.last
@@ -32,7 +32,7 @@ RSpec.describe "Delete/Cancel Subscription", type: :request do
 
   describe "sad paths" do
     it "returns an appropriate error if the subscription doesnt exist" do
-      delete "/api/v1/subscriptions/101278390"
+      patch "/api/v1/subscriptions/101278390/cancel"
       expect(response).to_not be_successful
 
       error = JSON.parse(response.body, symbolize_names: true)

--- a/spec/requests/subscriptions/delete_subscription.rb
+++ b/spec/requests/subscriptions/delete_subscription.rb
@@ -2,28 +2,29 @@ require 'rails_helper'
 
 RSpec.describe "Delete/Cancel Subscription", type: :request do
   before(:each) do
-    tea = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
-    customer = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
+    @tea = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
+    @customer = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
   end
 
   describe "When a user sends a DELETE request to /api/v1/subscriptions/{id}" do
     it "the requested subscription is cancelled" do
-      subscription = Subscription.create!(tea_id: tea.id, customer_id: customer.id, title: tea.title, price: 100.10, frequency: 7)
+      subscription = Subscription.create!(tea_id: @tea.id, customer_id: @customer.id, title: @tea.title, price: 100.10, frequency: 7)
       expect(subscription).to be_a Subscription
       expect(subscription.status).to eq("active")
-      expect(subscription.tea_id).to eq(tea.id)
-      expect(subscription.customer_id).to eq(customer.id)
-      expect(subscription.title).to eq(tea.title)
+      expect(subscription.tea_id).to eq(@tea.id)
+      expect(subscription.customer_id).to eq(@customer.id)
+      expect(subscription.title).to eq(@tea.title)
       expect(subscription.price).to eq(100.10)
       expect(subscription.frequency).to eq(7)
 
       delete "/api/v1/subscriptions/#{subscription.id}"
       expect(response).to be_successful
 
+      subscription = Subscription.last
       expect(subscription.status).to eq("cancelled")
-      expect(subscription.tea_id).to eq(tea.id)
-      expect(subscription.customer_id).to eq(customer.id)
-      expect(subscription.title).to eq(tea.title)
+      expect(subscription.tea_id).to eq(@tea.id)
+      expect(subscription.customer_id).to eq(@customer.id)
+      expect(subscription.title).to eq(@tea.title)
       expect(subscription.price).to eq(100.10)
       expect(subscription.frequency).to eq(7)
     end

--- a/spec/requests/subscriptions/delete_subscription.rb
+++ b/spec/requests/subscriptions/delete_subscription.rb
@@ -29,4 +29,16 @@ RSpec.describe "Delete/Cancel Subscription", type: :request do
       expect(subscription.frequency).to eq(7)
     end
   end
+
+  describe "sad paths" do
+    it "returns an appropriate error if the subscription doesnt exist" do
+      delete "/api/v1/subscriptions/101278390"
+      expect(response).to_not be_successful
+
+      error = JSON.parse(response.body, symbolize_names: true)
+      expect(error).to be_a Hash
+      expect(error).to have_key(:errors)
+      expect(error[:errors]).to eq("Subscription could not be found")
+    end
+  end
 end

--- a/spec/requests/subscriptions/delete_subscription.rb
+++ b/spec/requests/subscriptions/delete_subscription.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "Delete/Cancel Subscription", type: :request do
+  before(:each) do
+    tea = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
+    customer = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
+  end
+
+  describe "When a user sends a DELETE request to /api/v1/subscriptions/{id}" do
+    it "the requested subscription is cancelled" do
+      subscription = Subscription.create!(tea_id: tea.id, customer_id: customer.id, title: tea.title, price: 100.10, frequency: 7)
+      expect(subscription).to be_a Subscription
+      expect(subscription.status).to eq("active")
+      expect(subscription.tea_id).to eq(tea.id)
+      expect(subscription.customer_id).to eq(customer.id)
+      expect(subscription.title).to eq(tea.title)
+      expect(subscription.price).to eq(100.10)
+      expect(subscription.frequency).to eq(7)
+
+      delete "/api/v1/subscriptions/#{subscription.id}"
+      expect(response).to be_successful
+
+      expect(subscription.status).to eq("cancelled")
+      expect(subscription.tea_id).to eq(tea.id)
+      expect(subscription.customer_id).to eq(customer.id)
+      expect(subscription.title).to eq(tea.title)
+      expect(subscription.price).to eq(100.10)
+      expect(subscription.frequency).to eq(7)
+    end
+  end
+end


### PR DESCRIPTION
Resolves: #7 
Routes: PATCH api/v1/subscriptions/:id/cancel
Controllers: subscriptions#update
Testing: Full happy and sad path testing for cancellation requests

Features: Allows the cancellation of a subscritpion via the route above.

Design choice/notes: Was originally done via DELETE, but no resources were actually being deleted so it felt a bit smelly. Instead swapped to patching, and rather than front end needing to send a payload of "cancelled: true" or similar, just adding a cancel path to the URI.