### PR TITLE
Get subscriptions endpoint

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::SubscriptionsController < ApplicationController
+  def index
+    subscriptions = Subscription.where(customer_id: params[:customer_id])
+    render json: SubscriptionSerializer.new(subscriptions)
+  end
+
   def create
     details = JSON.parse(request.body.read, symbolize_names: true)
     tea = Tea.find_by(id: details[:tea_id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   namespace :api do 
     namespace :v1 do
-      resources :subscriptions, only: [:create] do
+      resources :subscriptions, only: [:create, :index] do
         patch "/cancel", to: "subscriptions#update"
       end
     end

--- a/spec/requests/subscriptions/get_subscriptions.rb
+++ b/spec/requests/subscriptions/get_subscriptions.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe "Get Subscriptions", type: :request do
+  before(:each) do
+    @tea_1 = Tea.create!(title: "A Cool Tea", description: "This tea rocks", temperature: 100, brew_time: 10)
+    @tea_2 = Tea.create!(title: "A Cool Tea 2", description: "This tea rocks", temperature: 100, brew_time: 10)
+    @tea_3 = Tea.create!(title: "A Cool Tea 3", description: "This tea rocks", temperature: 100, brew_time: 10)
+    @customer_1 = Customer.create!(first_name: "Kiwi", last_name: "Bird", email: "kiwibird@gmail.com", address: "1234 Bird Ln")
+    @customer_2 = Customer.create!(first_name: "Chicken", last_name: "Bird", email: "chicken@gmail.com", address: "1234 Bird Ln")
+    @sub_1 = Subscription.create!(tea_id: @tea_1.id, customer_id: @customer_1.id, title: @tea_1.title, price: 10.15, frequency: 14)
+    @sub_2 = Subscription.create!(tea_id: @tea_2.id, customer_id: @customer_1.id, title: @tea_2.title, price: 20.15, frequency: 30)
+    @sub_3 = Subscription.create!(tea_id: @tea_3.id, customer_id: @customer_2.id, title: @tea_3.title, price: 15.15, frequency: 14)
+  end
+
+  describe "When I make a get request to /api/v1/subscriptions with a query param of customer_id" do
+    it "I get back a json object of all active and cancelled subscriptions for that customer" do
+      get "/api/v1/subscriptions?customer_id=#{@customer_1.id}"
+      expect(response).to be_successful
+
+      subscriptions = JSON.parse(response.body, symbolize_names: true)
+      expect(subscriptions).to be_a Hash
+      expect(subscriptions).to have_key(:data)
+      expect(subscriptions[:data]).to be_an Array
+
+      subscriptions[:data].each do |subscription|
+        expect(subscription).to be_a Hash
+        expect(subscription).to have_key(:id)
+        expect(subscription[:id]).to be_a String
+        expect(subscription).to have_key(:type)
+        expect(subscription[:type]).to eq("subscription")
+        expect(subscription).to have_key(:attributes)
+        expect(subscription[:attributes]).to be_a Hash
+
+        attributes = subscription[:attributes]
+        expect(attributes).to have_key(:title)
+        expect(attributes[:title]).to be_a String
+        expect(attributes).to have_key(:price)
+        expect(attributes[:price]).to be_a Float
+        expect(attributes).to have_key(:status)
+        expect(attributes[:status]).to be_a String
+        expect(attributes).to have_key(:frequency)
+        expect(attributes[:frequency]).to be_an Integer
+      end
+    end
+
+    it "returns an empty data object if the customer has no subscriptions" do
+      customer_3 = Customer.create!(first_name: "Coco", last_name: "Bird", email: "coconut@gmail.com", address: "1234 Bird Ln")
+
+      get "/api/v1/subscriptions?customer_id=#{customer_3.id}"
+      expect(response).to be_successful
+
+      subscriptions = JSON.parse(response.body, symbolize_names: true)
+      expect(subscriptions).to be_a Hash
+      expect(subscriptions).to have_key(:data)
+      expect(subscriptions[:data]).to be_an Array
+      expect(subscriptions[:data]).to be_empty
+    end
+  end
+
+  describe "sad paths" do
+
+  end
+end

--- a/spec/requests/subscriptions/get_subscriptions.rb
+++ b/spec/requests/subscriptions/get_subscriptions.rb
@@ -42,22 +42,20 @@ RSpec.describe "Get Subscriptions", type: :request do
         expect(attributes[:frequency]).to be_an Integer
       end
     end
-
+  end
+  
+  describe "sad paths" do
     it "returns an empty data object if the customer has no subscriptions" do
       customer_3 = Customer.create!(first_name: "Coco", last_name: "Bird", email: "coconut@gmail.com", address: "1234 Bird Ln")
-
+  
       get "/api/v1/subscriptions?customer_id=#{customer_3.id}"
       expect(response).to be_successful
-
+  
       subscriptions = JSON.parse(response.body, symbolize_names: true)
       expect(subscriptions).to be_a Hash
       expect(subscriptions).to have_key(:data)
       expect(subscriptions[:data]).to be_an Array
       expect(subscriptions[:data]).to be_empty
     end
-  end
-
-  describe "sad paths" do
-
   end
 end


### PR DESCRIPTION
Resolves: #8 
Routes: GET /api/v1/subscriptions?customer_id={id}
Controllers: subscriptions#index
Testing: Full happy and sad path testing for getting a customer's subscriptions

Features: Allows the fetching of customer subscriptions via a customer_id query param on the subscriptions endpoint